### PR TITLE
Add tracking for last play messages

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -270,6 +270,17 @@ export class Game {
 		this.nextTurn();
 	}
 
+	lastPlayMsgs: { [chatId: number]: Promise<number> } = {};
+
+	async updatePlayMsg(text: string) {
+		this.log("Update message");
+		for (const [chatId, msgId] of Object.entries(this.lastPlayMsgs)) {
+			this.bot.deleteMessage(chatId, await msgId); // delete old message
+		}
+		const ids = [this.chatId].concat(this.playerIds);
+		ids.forEach(id => this.bot.sendMessage(id, text).then(m => m.message_id));
+	}
+
 	play(usr: User, cards: string[] | undefined) {
 		if (cards === undefined) {
 			this.message(usr.id, "Choose something to play");
@@ -297,7 +308,7 @@ export class Game {
 			} else {
 				this.high = resultMsg;
 				this.currRoundType = resultMsg.getRoundType();
-				this.broadcast(`${player.username} played ${resultMsg}`);
+				this.updatePlayMsg(`${player.username} played ${resultMsg}`);
 				this.nextTurn();
 			}
 


### PR DESCRIPTION
Track messages containing the last play, delete the old message once the next player plays a combination, prevent the user from looking through the discard pile.
Addresses #13 but faces some async issues currently.